### PR TITLE
chore: require at least node 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ node_modules/
 tmp/
 *.log
 .idea/
-coverage/
+.nyc_output/
+package-lock.json

--- a/eslint.js
+++ b/eslint.js
@@ -129,8 +129,5 @@ module.exports = {
   env: {
     node: true,
     es6: true
-  },
-  parserOptions: {
-    ecmaVersion: 6
   }
 };

--- a/eslint.js
+++ b/eslint.js
@@ -131,6 +131,6 @@ module.exports = {
     es6: true
   },
   parserOptions: {
-    ecmaVersion: 2018
+    ecmaVersion: 6
   }
 };

--- a/eslint.js
+++ b/eslint.js
@@ -131,6 +131,6 @@ module.exports = {
     es6: true
   },
   parserOptions: {
-    ecmaVersion: 6
+    ecmaVersion: 2018
   }
 };

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 3.1.0"
+    "eslint": ">= 5.0.0"
   },
   "dependencies": {
-    "eslint-plugin-node": "^5.2.1"
+    "eslint-plugin-node": "^9.1.0"
+  },
+  "engines": {
+    "node": ">=8.6.0"
   }
 }


### PR DESCRIPTION
* add support for ES2019 (through eslint-plugin-node@9, see next comment)
  - Node 8 only [partially supports](https://node.green/#ES2018) ES2018 and ES2019, node 8 in travis (of other repos that uses this) should fail when using unsupported es2018/es2019 features.
* update to eslint-plugin-node@9 to support node 12. It still supports eslint@5, but requires >=8.10.0 which is higher than hexo's (https://github.com/hexojs/hexo/issues/3508#issuecomment-502423979). eslint-plugin-node@8 may be safer.
* ignore nyc logs and package-lock. "coverage/" is used by the deprecated istanbul.