### PR TITLE
fix: whatwg url api is not supported by node 8

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -124,7 +124,11 @@ module.exports = {
     'no-useless-rename': 'error',
     'rest-spread-spacing': ['error', 'never'],
     'template-curly-spacing': ['error', 'never'],
-    'yield-star-spacing': ['error', 'after']
+    'yield-star-spacing': ['error', 'after'],
+    // Node 8 compatibility
+    'node/no-deprecated-api': ['error', {
+      'ignoreModuleItems': ['url.parse', 'url.resolve']
+    }]
   },
   env: {
     node: true,


### PR DESCRIPTION
When using the master branch, test with hexo-generator-feed yields the following error:
```
'url.parse' was deprecated since v11.0.0. Use 'url.URL' constructor instead  node/no-deprecated-api
```

[old URL API](https://nodejs.org/api/url.html#url_legacy_url_api) is required for Node 8 compatibility, Node 8 doesn't support the [new URL API](https://nodejs.org/api/url.html#url_the_whatwg_url_api).