### PR TITLE
feat: enable no-console

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -3,7 +3,6 @@ module.exports = {
   plugins: ['node'],
   rules: {
     // override recommended
-    'no-console': 'off',
     'no-empty': ['error', { allowEmptyCatch: true }],
     'no-unused-vars': ['error', { args: 'none' }],
     // Possible Errors


### PR DESCRIPTION
there were a few instances where I accidentally pushed commits with `console.log()`. Most of the hexo repos don't use it, so it's viable to disable the rule in individual repo.

can be part of v5.