### PR TITLE
Update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 20

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 5.0.0"
+    "eslint": ">= 8.1.0"
   },
   "dependencies": {
     "eslint-plugin-node": "^11.1.0",
-    "@typescript-eslint/eslint-plugin": "^4.28.3",
-    "@typescript-eslint/parser": "^4.28.3"
+    "@typescript-eslint/eslint-plugin": "^5.7.0",
+    "@typescript-eslint/parser": "^5.7.0"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=12.22.0"
   }
 }


### PR DESCRIPTION
Update of @typescript-eslint/* triggered an update of minimal version of eslint (8.1+) and node engine (12+)