### PR TITLE
chore: require `node.js18+`, replace `eslint-plugin-node` and update dependencies

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -1,6 +1,6 @@
 module.exports = {
-  extends: ['eslint:recommended', 'plugin:node/recommended'],
-  plugins: ['node'],
+  extends: ['eslint:recommended', 'plugin:n/recommended'],
+  plugins: ['n'],
   rules: {
     // override recommended
     'no-empty': ['error', { allowEmptyCatch: true }],
@@ -132,10 +132,6 @@ module.exports = {
     'rest-spread-spacing': 'error',
     'template-curly-spacing': 'error',
     'yield-star-spacing': 'error',
-    // Node 8 compatibility
-    'node/no-deprecated-api': ['error', {
-      'ignoreModuleItems': ['url.parse', 'url.resolve']
-    }]
   },
   env: {
     node: true,

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 8.1.0"
+    "eslint": ">= 8.23.0"
   },
   "dependencies": {
-    "eslint-plugin-node": "^11.1.0",
-    "@typescript-eslint/eslint-plugin": "^5.7.0",
-    "@typescript-eslint/parser": "^5.7.0"
+    "eslint-plugin-n": "^17.9.0",
+    "@typescript-eslint/eslint-plugin": "^7.15.0",
+    "@typescript-eslint/parser": "^7.15.0"
   },
   "engines": {
-    "node": ">=12.22.0"
+    "node": ">=18"
   }
 }

--- a/ts.js
+++ b/ts.js
@@ -6,7 +6,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended'
   ],
   rules: {
-    'node/no-unsupported-features/es-syntax': ['error', { 'ignores': ['modules'] }],
-    'node/no-missing-import': ['error', { 'tryExtensions': ['.js', '.ts'] }]
+    'n/no-unsupported-features/es-syntax': ['error', { 'ignores': ['modules'] }],
+    'n/no-missing-import': ['error', { 'tryExtensions': ['.js', '.ts'] }]
   }
 };


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Changes

- require node.js 18+ (drop 14.x, 16.x)
- replace `eslint-plugin-node`
    - [eslint-plugin-node is deprecated](https://github.com/mysticatea/eslint-plugin-node)
- bump `eslint` in peerDeps
    - [eslint-plugin-n](https://github.com/eslint-community/eslint-plugin-n) requires `eslint 8.23+`
- bump other deps

## Others

I'm going to migrate eslint to 9.x after merge this PR. Thanks :)