### PR TITLE
feat: migrate to `FlatConfig`

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -1,5 +1,6 @@
 import nodePlugin from 'eslint-plugin-n';
 import eslintJs from '@eslint/js';
+import globals from 'globals';
 
 const commonConfig = {
   languageOptions: {

--- a/eslint.js
+++ b/eslint.js
@@ -9,9 +9,6 @@ const commonConfig = {
       ...globals.es6,
     },
   },
-  plugins: {
-    n: nodePlugin,
-  },
   rules: {
     // override recommended
     'no-empty': ['error', { allowEmptyCatch: true }],
@@ -148,6 +145,6 @@ const commonConfig = {
 
 export default [
   eslintJs.configs.recommended,
-  ...nodePlugin.configs.recommended,
+  nodePlugin.configs["flat/recommended-script"],
   commonConfig,
 ];

--- a/eslint.js
+++ b/eslint.js
@@ -1,6 +1,16 @@
-module.exports = {
-  extends: ['eslint:recommended', 'plugin:n/recommended'],
-  plugins: ['n'],
+import nodePlugin from 'eslint-plugin-n';
+import eslintJs from '@eslint/js';
+
+const commonConfig = {
+  languageOptions: {
+    globals: {
+      ...globals.node,
+      ...globals.es6,
+    },
+  },
+  plugins: {
+    nodePlugin,
+  },
   rules: {
     // override recommended
     'no-empty': ['error', { allowEmptyCatch: true }],
@@ -133,8 +143,10 @@ module.exports = {
     'template-curly-spacing': 'error',
     'yield-star-spacing': 'error',
   },
-  env: {
-    node: true,
-    es6: true
-  }
 };
+
+export default [
+  eslintJs.configs.recommended,
+  ...nodePlugin.configs.recommended,
+  commonConfig,
+];

--- a/eslint.js
+++ b/eslint.js
@@ -10,7 +10,7 @@ const commonConfig = {
     },
   },
   plugins: {
-    nodePlugin,
+    n: nodePlugin,
   },
   rules: {
     // override recommended

--- a/eslint.js
+++ b/eslint.js
@@ -1,6 +1,6 @@
-import nodePlugin from 'eslint-plugin-n';
-import eslintJs from '@eslint/js';
-import globals from 'globals';
+const nodePlugin = require('eslint-plugin-n');
+const eslintJs = require('@eslint/js');
+const globals = require('globals');
 
 const commonConfig = {
   languageOptions: {
@@ -143,7 +143,7 @@ const commonConfig = {
   },
 };
 
-export default [
+module.exports = [
   eslintJs.configs.recommended,
   nodePlugin.configs["flat/recommended-script"],
   commonConfig,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@eslint/js": "^9.13.0",
     "eslint-plugin-n": "^17.12.0",
     "globals": "^15.11.0",
-    "typescript-eslint": "^8.12.2"
+    "typescript-eslint": "^8.12.2",
+    "eslint-plugin-mocha": "^10.5.0"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@eslint/js": "^9.10.0",
     "eslint-plugin-n": "^17.10.3",
+    "globals": "^15.9.0",
     "typescript-eslint": "^8.6.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 8.23.0"
+    "eslint": ">= 9.10.0"
   },
   "dependencies": {
-    "eslint-plugin-n": "^17.9.0",
-    "@typescript-eslint/eslint-plugin": "^7.15.0",
-    "@typescript-eslint/parser": "^7.15.0"
+    "@eslint/js": "^9.10.0",
+    "eslint-plugin-n": "^17.10.3",
+    "typescript-eslint": "^8.6.0"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 9.10.0"
+    "eslint": ">= 9.13.0"
   },
   "dependencies": {
-    "@eslint/js": "^9.10.0",
-    "eslint-plugin-n": "^17.10.3",
-    "globals": "^15.9.0",
-    "typescript-eslint": "^8.6.0"
+    "@eslint/js": "^9.13.0",
+    "eslint-plugin-n": "^17.12.0",
+    "globals": "^15.11.0",
+    "typescript-eslint": "^8.12.2"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "eslint": ">= 9.13.0"
+    "eslint": ">= 9.17.0"
   },
   "dependencies": {
-    "@eslint/js": "^9.13.0",
-    "eslint-plugin-n": "^17.12.0",
-    "globals": "^15.11.0",
-    "typescript-eslint": "^8.12.2",
+    "@eslint/js": "^9.17.0",
+    "eslint-plugin-n": "^17.15.1",
+    "globals": "^15.14.0",
+    "typescript-eslint": "^8.19.0",
     "eslint-plugin-mocha": "^10.5.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "ts-test.js"
   ],
   "exports": {
-    "./eslint" : "./eslint.js",
-    "./test" : "./test.js",
-    "./ts" : "./ts.js",
-    "./ts-test" : "./ts-test.js"
+    "./eslint": "./eslint.js",
+    "./test": "./test.js",
+    "./ts": "./ts.js",
+    "./ts-test": "./ts-test.js"
   },
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "maintainers": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "ts.js",
     "ts-test.js"
   ],
+  "exports": {
+    "./eslint" : "./eslint.js",
+    "./test" : "./test.js",
+    "./ts" : "./ts.js",
+    "./ts-test" : "./ts-test.js"
+  },
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "maintainers": [
     "Abner Chou <hi@abnerchou.me> (http://abnerchou.me)"

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const eslint = require('./eslint.js');
+const jsConfig = require('./eslint.js');
 const globals = require('globals');
 const mochaPlugin = require('eslint-plugin-mocha');
 
@@ -18,6 +18,6 @@ const testConfig = {
 };
 
 module.exports = [
-  ...eslint,
+  ...jsConfig,
   testConfig
 ];

--- a/test.js
+++ b/test.js
@@ -1,9 +1,17 @@
-module.exports = {
-  extends: './eslint.js',
+import eslint from './eslint';
+
+const testConfig = {
+  languageOptions: {
+    globals: {
+      ...globals.mocha
+    },
+  },
   rules: {
     'no-unused-expressions': 'off'
   },
-  env: {
-    mocha: true
-  }
 };
+
+export default [
+  eslint,
+  testConfig,
+];

--- a/test.js
+++ b/test.js
@@ -13,6 +13,6 @@ const testConfig = {
 };
 
 export default [
-  eslint,
+  ...eslint,
   testConfig,
 ];

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import eslint from './eslint';
+import eslint from 'eslint';
 import globals from 'globals';
 
 const testConfig = {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 const eslint = require('./eslint.js');
 const globals = require('globals');
+const mochaPlugin = require('eslint-plugin-mocha');
 
 const testConfig = {
   languageOptions: {
@@ -12,7 +13,17 @@ const testConfig = {
   },
 };
 
+const mochaConfig = {
+  ...mochaPlugin.configs.flat.recommended,
+  rules: {
+    "mocha/no-mocha-arrows": 0,
+    "mocha/handle-done-callback": 0,
+    "mocha/max-top-level-suites": 0,
+  }
+};
+
 module.exports = [
   ...eslint,
   testConfig,
+  mochaConfig,
 ];

--- a/test.js
+++ b/test.js
@@ -3,27 +3,21 @@ const globals = require('globals');
 const mochaPlugin = require('eslint-plugin-mocha');
 
 const testConfig = {
+  ...mochaPlugin.configs.flat.recommended,
   languageOptions: {
     globals: {
       ...globals.mocha
     },
   },
   rules: {
-    'no-unused-expressions': 'off'
-  },
-};
-
-const mochaConfig = {
-  ...mochaPlugin.configs.flat.recommended,
-  rules: {
+    'no-unused-expressions': 0,
     "mocha/no-mocha-arrows": 0,
     "mocha/handle-done-callback": 0,
     "mocha/max-top-level-suites": 0,
-  }
+  },
 };
 
 module.exports = [
   ...eslint,
-  testConfig,
-  mochaConfig,
+  testConfig
 ];

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-import eslint from './eslint.js';
-import globals from 'globals';
+const eslint = require('./eslint.js');
+const globals = require('globals');
 
 const testConfig = {
   languageOptions: {
@@ -12,7 +12,7 @@ const testConfig = {
   },
 };
 
-export default [
+module.exports = [
   ...eslint,
   testConfig,
 ];

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-import eslint from 'eslint';
+import eslint from './eslint.js';
 import globals from 'globals';
 
 const testConfig = {

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import eslint from './eslint';
+import globals from 'globals';
 
 const testConfig = {
   languageOptions: {

--- a/ts-test.js
+++ b/ts-test.js
@@ -13,6 +13,6 @@ const tsTestConfig = {
 };
 
 export default [
-  tsJs,
+  ...tsJs,
   tsTestConfig,
 ];

--- a/ts-test.js
+++ b/ts-test.js
@@ -1,9 +1,17 @@
-module.exports = {
-  extends: './ts.js',
+import tsJs from './tsts';
+
+const tsTestConfig = {
+  languageOptions: {
+    globals: {
+      ...globals.mocha
+    },
+  },
   rules: {
     'no-unused-expressions': 'off'
   },
-  env: {
-    mocha: true
-  }
 };
+
+export default [
+  tsJs,
+  tsTestConfig,
+];

--- a/ts-test.js
+++ b/ts-test.js
@@ -1,4 +1,5 @@
 import tsJs from './tsts';
+import globals from 'globals';
 
 const tsTestConfig = {
   languageOptions: {

--- a/ts-test.js
+++ b/ts-test.js
@@ -1,4 +1,4 @@
-import tsJs from './tsts';
+import tsJs from 'ts.js';
 import globals from 'globals';
 
 const tsTestConfig = {

--- a/ts-test.js
+++ b/ts-test.js
@@ -1,4 +1,4 @@
-import tsJs from 'ts.js';
+import tsJs from './ts.js';
 import globals from 'globals';
 
 const tsTestConfig = {

--- a/ts-test.js
+++ b/ts-test.js
@@ -1,4 +1,4 @@
-const tsJs = require('./ts.js');
+const tsConfig = require('./ts.js');
 const globals = require('globals');
 
 const tsTestConfig = {
@@ -13,6 +13,6 @@ const tsTestConfig = {
 };
 
 module.exports = [
-  ...tsJs,
+  ...tsConfig,
   tsTestConfig,
 ];

--- a/ts-test.js
+++ b/ts-test.js
@@ -1,5 +1,5 @@
-import tsJs from './ts.js';
-import globals from 'globals';
+const tsJs = require('./ts.js');
+const globals = require('globals');
 
 const tsTestConfig = {
   languageOptions: {
@@ -12,7 +12,7 @@ const tsTestConfig = {
   },
 };
 
-export default [
+module.exports = [
   ...tsJs,
   tsTestConfig,
 ];

--- a/ts.js
+++ b/ts.js
@@ -10,9 +10,6 @@ const nodeConfig = {
 }
 
 const tslintConfig = tseslint.config({
-  plugins: {
-    '@typescript-eslint': tseslint.plugin,
-  },
   languageOptions: {
     parser: tseslint.parser,
     parserOptions: {

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,6 @@
-import tseslint from 'typescript-eslint';
-import nodePlugin from 'eslint-plugin-n';
-import eslint from './eslint.js';
+const tseslint = require('typescript-eslint');
+const nodePlugin = require('eslint-plugin-n');
+const eslint = require('./eslint.js');
 
 const nodeConfig = {
   rules: {
@@ -9,7 +9,7 @@ const nodeConfig = {
   },
 }
 
-export default [].concat(
+module.exports = [].concat(
   eslint,
   nodePlugin.configs["flat/mixed-esm-and-cjs"],
   ...tseslint.configs.recommended,

--- a/ts.js
+++ b/ts.js
@@ -18,9 +18,9 @@ const tslintConfig = tseslint.config({
   },
 });
 
-export default [
+export default [].concat(
   eslint,
-  ...nodePlugin.configs["flat/mixed-esm-and-cjs"],
+  nodePlugin.configs["flat/mixed-esm-and-cjs"],
   tslintConfig,
   nodeConfig,
-];
+);

--- a/ts.js
+++ b/ts.js
@@ -9,18 +9,9 @@ const nodeConfig = {
   },
 }
 
-const tslintConfig = tseslint.config({
-  languageOptions: {
-    parser: tseslint.parser,
-    parserOptions: {
-      project: true,
-    },
-  },
-});
-
 export default [].concat(
   eslint,
   nodePlugin.configs["flat/mixed-esm-and-cjs"],
-  tslintConfig,
+  ...tseslint.configs.recommended,
   nodeConfig,
 );

--- a/ts.js
+++ b/ts.js
@@ -1,12 +1,29 @@
-module.exports = {
-  parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
-  extends: [
-    './eslint.js',
-    'plugin:@typescript-eslint/recommended'
-  ],
+import tseslint from 'typescript-eslint';
+import nodePlugin from 'eslint-plugin-n';
+import eslint from './eslint';
+
+const nodeConfig = {
   rules: {
     'n/no-unsupported-features/es-syntax': ['error', { 'ignores': ['modules'] }],
     'n/no-missing-import': ['error', { 'tryExtensions': ['.js', '.ts'] }]
-  }
-};
+  },
+}
+
+const tslintConfig = tseslint.config({
+  plugins: {
+    '@typescript-eslint': tseslint.plugin,
+  },
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      project: true,
+    },
+  },
+});
+
+export default [
+  eslint,
+  ...nodePlugin.configs["flat/mixed-esm-and-cjs"],
+  tslintConfig,
+  nodeConfig,
+];

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,6 @@
 import tseslint from 'typescript-eslint';
 import nodePlugin from 'eslint-plugin-n';
-import eslint from './eslint';
+import eslint from 'eslint';
 
 const nodeConfig = {
   rules: {

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,6 @@
 import tseslint from 'typescript-eslint';
 import nodePlugin from 'eslint-plugin-n';
-import eslint from 'eslint';
+import eslint from './eslint.js';
 
 const nodeConfig = {
   rules: {

--- a/ts.js
+++ b/ts.js
@@ -1,6 +1,6 @@
-const tseslint = require('typescript-eslint');
+const tsEslint = require('typescript-eslint');
 const nodePlugin = require('eslint-plugin-n');
-const eslint = require('./eslint.js');
+const jsConfig = require('./eslint.js');
 
 const nodeConfig = {
   rules: {
@@ -10,8 +10,8 @@ const nodeConfig = {
 }
 
 module.exports = [].concat(
-  eslint,
+  jsConfig,
   nodePlugin.configs["flat/mixed-esm-and-cjs"],
-  ...tseslint.configs.recommended,
+  ...tsEslint.configs.recommended,
   nodeConfig,
 );


### PR DESCRIPTION
Refs: #55 

## check list

- [ ] ~Add test cases for the changes.~
- [ ] ~Passed the CI test.~

## Usage

```
// Before FlatConfig
{
  "root": true,
  "extends": "hexo/ts.js",
  "parserOptions": {
    "sourceType": "module",
    "ecmaVersion": 2020
  },
  "rules": {
    "@typescript-eslint/no-explicit-any": 0,
    "@typescript-eslint/ban-ts-comment": 0,
    "@typescript-eslint/no-this-alias": 0
  }
}
```

```js
// After
// In `eslint.config.js`
const hexoTsLint = require('eslint-config-hexo/ts');

module.exports = [
  ...hexoTsLint,
  {
    languageOptions: {
      ecmaVersion: 2022,
    },
    rules: {
      "@typescript-eslint/no-explicit-any": 0,
      "@typescript-eslint/ban-ts-comment": 0,
      "@typescript-eslint/no-this-alias": 0
    }
  }
];
```